### PR TITLE
Fixing a broken link in index.md

### DIFF
--- a/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
+++ b/guides/tutorials/codelabs/kubernetes-v2-source-to-prod/index.md
@@ -123,7 +123,7 @@ hal config provider kubernetes account add staging-demo \
 
 ### Configure GitHub artifact credentials
 
-Make sure to [add GitHub as an artifact account](/setup/artifacts/github). This
+Make sure to [add GitHub as an artifact account](/setup/artifacts/github.md). This
 will allow us to fetch the manifests later.
 
 ### Deploy Spinnaker


### PR DESCRIPTION
'Adding GitHub as an artifact account' link now directs to the intended page